### PR TITLE
Enforce only 1 thread for `download_eggnog_db`

### DIFF
--- a/sbx_eggnog.rules
+++ b/sbx_eggnog.rules
@@ -25,6 +25,7 @@ rule download_eggnog_db:
 		str(ANNOTATION_FP/'eggnog'/'data'/'eggnog.db')
 	params:
 		db_path = str(ANNOTATION_FP/'eggnog'/'data')
+	threads: 1
 	shell:
 		"""
 		download_eggnog_data.py bact arch viruses --data_dir {params.db_path} -y 


### PR DESCRIPTION
I don't know whether Snakemake will try to throw more cores at this job if they are available (I think it might) but we can avert this by explicitly only giving one.